### PR TITLE
feat: add Exam and Question management functionality with DTOs and se…

### DIFF
--- a/src/main/java/com/example/pal/controller/ExamController.java
+++ b/src/main/java/com/example/pal/controller/ExamController.java
@@ -1,0 +1,53 @@
+package com.example.pal.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.pal.dto.CreateExamDTO;
+import com.example.pal.dto.ExamDTO;
+import com.example.pal.service.ExamService;
+
+
+@RestController
+@RequestMapping("/api/exams")
+public class ExamController {
+
+    @Autowired
+    private ExamService examService;
+
+    @PostMapping("/create")
+    public ResponseEntity<ExamDTO> createExam(@RequestBody CreateExamDTO examDTO) {
+        ExamDTO newExam = examService.createExam(examDTO);
+        return ResponseEntity.ok(newExam);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<ExamDTO>> getAllExams() {
+        List<ExamDTO> exams = examService.getAllExams();
+        return ResponseEntity.ok(exams);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ExamDTO> getExamById(@PathVariable Long id) {
+        ExamDTO exam = examService.getExamById(id);
+        return ResponseEntity.ok(exam);
+    }
+
+    @PutMapping("/update/{id}")
+    public ResponseEntity<ExamDTO> updateExam(@PathVariable("id") Long id, @RequestBody CreateExamDTO examDTO) {
+        ExamDTO updatedExam = examService.updateExam(id, examDTO);
+        return ResponseEntity.ok(updatedExam);
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteExam(@PathVariable("id") Long id) {
+        examService.deleteExam(id);
+        return ResponseEntity.noContent().build();
+    }
+    
+}

--- a/src/main/java/com/example/pal/controller/QuestionController.java
+++ b/src/main/java/com/example/pal/controller/QuestionController.java
@@ -1,0 +1,54 @@
+
+package com.example.pal.controller;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.pal.dto.CreateQuestionDTO;
+import com.example.pal.dto.QuestionDTO;
+import com.example.pal.service.QuestionService;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/questions")
+public class QuestionController {
+    
+    @Autowired
+    private QuestionService questionService;
+
+    @PostMapping("/create")
+    public ResponseEntity<QuestionDTO> createQuestion(@RequestBody CreateQuestionDTO questionDTO) {
+        QuestionDTO newQuestion = questionService.createQuestion(questionDTO);
+        return ResponseEntity.ok(newQuestion);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<QuestionDTO>> getAllQuestions() {
+        List<QuestionDTO> questions = questionService.getAllQuestions();
+        return ResponseEntity.ok(questions);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<QuestionDTO> getQuestionById(@PathVariable Long id) {
+        QuestionDTO question = questionService.getQuestionById(id);
+        return ResponseEntity.ok(question);
+    }
+
+    @PutMapping("/update/{id}")
+    public ResponseEntity<QuestionDTO> updateQuestion(@PathVariable("id") Long id, @RequestBody CreateQuestionDTO questionDTO) {
+        QuestionDTO updatedQuestion = questionService.updateQuestion(id, questionDTO);
+        return ResponseEntity.ok(updatedQuestion);
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteQuestion(@PathVariable("id") Long id) {
+        questionService.deleteQuestion(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
+}

--- a/src/main/java/com/example/pal/dto/CourseDTO.java
+++ b/src/main/java/com/example/pal/dto/CourseDTO.java
@@ -14,4 +14,5 @@ public class CourseDTO {
     private UserDTO instructor;
     private CategoryDTO category;
     private Set<ContentDTO> contents;
+    private Set<ExamDTO> exams;
 }

--- a/src/main/java/com/example/pal/dto/CreateExamDTO.java
+++ b/src/main/java/com/example/pal/dto/CreateExamDTO.java
@@ -1,0 +1,8 @@
+package com.example.pal.dto;
+import lombok.Data;
+
+@Data
+public class CreateExamDTO {
+    private String title;
+    private Long course;
+}

--- a/src/main/java/com/example/pal/dto/CreateQuestionDTO.java
+++ b/src/main/java/com/example/pal/dto/CreateQuestionDTO.java
@@ -1,0 +1,11 @@
+package com.example.pal.dto;
+import lombok.Data;
+
+@Data
+public class CreateQuestionDTO {
+    
+    
+    private String content;
+    private String answer;
+    private Long exam;
+}

--- a/src/main/java/com/example/pal/dto/ExamDTO.java
+++ b/src/main/java/com/example/pal/dto/ExamDTO.java
@@ -1,0 +1,11 @@
+package com.example.pal.dto;
+import java.util.Set;
+
+import lombok.Data;
+
+@Data
+public class ExamDTO {
+    private Long id;
+    private String title;
+    private Set<QuestionDTO> questions;
+}

--- a/src/main/java/com/example/pal/dto/QuestionDTO.java
+++ b/src/main/java/com/example/pal/dto/QuestionDTO.java
@@ -1,0 +1,9 @@
+package com.example.pal.dto;
+import lombok.Data;
+
+@Data
+public class QuestionDTO {
+    private Long id;
+    private String content;
+    private String answer;
+}

--- a/src/main/java/com/example/pal/model/Course.java
+++ b/src/main/java/com/example/pal/model/Course.java
@@ -45,5 +45,9 @@ public class Course {
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private Set<Content> contents;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private Set<Exam> exams;
     
 }

--- a/src/main/java/com/example/pal/model/Exam.java
+++ b/src/main/java/com/example/pal/model/Exam.java
@@ -1,0 +1,53 @@
+package com.example.pal.model;
+import java.util.Objects;
+import java.util.Set;
+
+import com.example.pal.model.Course;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "exams")
+public class Exam {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @ManyToOne
+    @JsonIgnore
+    private Course course;
+
+    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL)
+    @JsonManagedReference
+    private Set<Question> questions;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Exam)) return false;
+        Exam exam = (Exam) o;
+        return Objects.equals(id, exam.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/src/main/java/com/example/pal/model/Question.java
+++ b/src/main/java/com/example/pal/model/Question.java
@@ -1,0 +1,32 @@
+package com.example.pal.model;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+
+
+@Entity
+@Data
+@Table(name = "questions")
+public class Question {
+    @Id 
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String answer;
+
+    @ManyToOne
+    @JsonIgnore
+    private Exam exam;
+}

--- a/src/main/java/com/example/pal/repository/ExamRepository.java
+++ b/src/main/java/com/example/pal/repository/ExamRepository.java
@@ -1,0 +1,14 @@
+package com.example.pal.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.example.pal.model.Exam;
+
+@Repository
+public interface ExamRepository extends JpaRepository<Exam, Long> {
+    
+    Optional<Exam> findById(long id);
+    Optional<Exam> findByTitle(String title);
+}

--- a/src/main/java/com/example/pal/repository/QuestionRepository.java
+++ b/src/main/java/com/example/pal/repository/QuestionRepository.java
@@ -1,0 +1,12 @@
+package com.example.pal.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.pal.model.Question;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Optional<Question> findById(long id);
+}

--- a/src/main/java/com/example/pal/service/ExamService.java
+++ b/src/main/java/com/example/pal/service/ExamService.java
@@ -1,0 +1,75 @@
+package com.example.pal.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.stereotype.Service;
+
+import com.example.pal.dto.CreateExamDTO;
+import com.example.pal.dto.ExamDTO;
+import com.example.pal.model.Course;
+import com.example.pal.model.Exam;
+import com.example.pal.repository.CourseRepository;
+import com.example.pal.repository.ExamRepository;
+
+
+
+@Service
+public class ExamService {
+    
+    @Autowired
+    private ExamRepository examRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public ExamDTO createExam(CreateExamDTO examDTO) {
+        Course course = courseRepository.findById(examDTO.getCourse()).orElseThrow(() -> new RuntimeException("Course not found"));
+        
+        Exam existingExam = examRepository.findByTitle(examDTO.getTitle()).orElse(null);
+        if (existingExam != null) {
+            // Si existe un examen con el mismo título, no se puede crear uno nuevo
+            throw new RuntimeException("Ya existe un examen con ese nombre");
+        }
+
+        Exam newExam = modelMapper.map(examDTO, Exam.class);
+        newExam.setTitle(examDTO.getTitle());
+        newExam.setCourse(course);
+        
+        Exam savedExam = examRepository.save(newExam);
+        return modelMapper.map(savedExam, ExamDTO.class);
+    }
+
+    public List<ExamDTO> getAllExams() {
+        return examRepository.findAll().stream()
+                .map(exam -> modelMapper.map(exam, ExamDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    public ExamDTO getExamById(Long id) {
+        Exam exam = examRepository.findById(id).orElseThrow(() -> new RuntimeException("Exam not found!"));
+        return modelMapper.map(exam, ExamDTO.class);
+    }
+
+    public ExamDTO updateExam(Long id, CreateExamDTO examDTO) {
+        Exam existingExam = examRepository.findById(id).orElseThrow(() -> new RuntimeException("Exam not found!"));
+        
+        Course course = courseRepository.findById(examDTO.getCourse()).orElseThrow(() -> new RuntimeException("Course not found"));
+        existingExam.setTitle(examDTO.getTitle());
+        existingExam.setCourse(course);
+        Exam updatedExam = examRepository.save(existingExam);
+        return modelMapper.map(updatedExam, ExamDTO.class);
+    }
+    
+
+    public void deleteExam(Long id) {
+        Exam exam = examRepository.findById(id).orElseThrow(() -> new RuntimeException("Exam not found!"));
+        examRepository.delete(exam);
+    }
+}

--- a/src/main/java/com/example/pal/service/QuestionService.java
+++ b/src/main/java/com/example/pal/service/QuestionService.java
@@ -1,0 +1,71 @@
+package com.example.pal.service;
+import org.springframework.stereotype.Service;
+
+import com.example.pal.dto.CreateQuestionDTO;
+import com.example.pal.model.Question;
+import com.example.pal.repository.QuestionRepository;
+
+import com.example.pal.dto.QuestionDTO;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.pal.model.Exam;
+import com.example.pal.repository.ExamRepository;
+
+
+@Service
+public class QuestionService {
+    
+    @Autowired
+    private QuestionRepository questionRepository;
+    
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Autowired
+    private ExamRepository examRepository;
+
+    public QuestionDTO createQuestion(CreateQuestionDTO questionDTO) {
+        Exam exam = examRepository.findById(questionDTO.getExam()).orElseThrow(() -> new RuntimeException("Exam not found"));
+
+
+        Question newQuestion = modelMapper.map(questionDTO, Question.class);
+        newQuestion.setExam(exam);
+        newQuestion.setContent(questionDTO.getContent());
+        newQuestion.setAnswer(questionDTO.getAnswer());
+        Question savedQuestion = questionRepository.save(newQuestion);
+        return modelMapper.map(savedQuestion, QuestionDTO.class);
+        
+    }
+
+    public List<QuestionDTO> getAllQuestions() {
+        return questionRepository.findAll().stream()
+                .map(question -> modelMapper.map(question, QuestionDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    public QuestionDTO getQuestionById(Long id) {
+        Question question = questionRepository.findById(id).orElseThrow(() -> new RuntimeException("Question not found!"));
+        return modelMapper.map(question, QuestionDTO.class);
+    }
+
+    public QuestionDTO updateQuestion(Long id, CreateQuestionDTO questionDTO) {
+        
+        Question question = questionRepository.findById(id).orElseThrow(() -> new RuntimeException("Question not found!"));
+        question.setContent(questionDTO.getContent());
+        question.setAnswer(questionDTO.getAnswer());
+        question.setExam(examRepository.findById(questionDTO.getExam()).orElseThrow(() -> new RuntimeException("Exam not found")));
+        Question updatedQuestion = questionRepository.save(question);
+        return modelMapper.map(updatedQuestion, QuestionDTO.class);
+    }
+
+    public void deleteQuestion(Long id) {
+        Question question = questionRepository.findById(id).orElseThrow(() -> new RuntimeException("Question not found!"));
+        questionRepository.delete(question);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new feature to manage exams and questions within the application. It includes the creation of controllers, services, models, DTOs, and repositories for both entities, as well as their integration into the existing course structure. Below is a summary of the most important changes, grouped by theme:

### Controller and Service Layer Additions
* Added `ExamController` and `QuestionController` to handle CRUD operations for exams and questions via REST endpoints. (`src/main/java/com/example/pal/controller/ExamController.java`, `src/main/java/com/example/pal/controller/QuestionController.java`) [[1]](diffhunk://#diff-ea822c3bc6132e81b8c4f289c7730f68fd47e24f096b2154e0672995b1ebf16eR1-R53) [[2]](diffhunk://#diff-e173dba142861b935694d04a3a3bba53041e196e7211c216093c7f4c24899c54R1-R54)
* Implemented `ExamService` and `QuestionService` to encapsulate business logic for managing exams and questions, including validation and mapping between DTOs and entities. (`src/main/java/com/example/pal/service/ExamService.java`, `src/main/java/com/example/pal/service/QuestionService.java`) [[1]](diffhunk://#diff-7e28fc382aa1f6c4c7b3c06c76145a56d5786b660b947646d80d260abaa70f2aR1-R75) [[2]](diffhunk://#diff-04073c63230e43e20c74eef0a8025d9ec2a6b635ed4a8508e9b1769ee2fe3642R1-R71)

### Data Transfer Objects (DTOs)
* Created `ExamDTO`, `CreateExamDTO`, `QuestionDTO`, and `CreateQuestionDTO` to define the data structures for transferring exam and question data between layers. (`src/main/java/com/example/pal/dto/ExamDTO.java`, `src/main/java/com/example/pal/dto/CreateExamDTO.java`, `src/main/java/com/example/pal/dto/QuestionDTO.java`, `src/main/java/com/example/pal/dto/CreateQuestionDTO.java`) [[1]](diffhunk://#diff-5d8360f2ea5f8d2e3389a3e6e33831a20a43ace1a5f13654a17f85b9c5a64283R1-R11) [[2]](diffhunk://#diff-6ca8f6c235a0a83e20c60400cef84ef781d7e0cba57deafda1436113bb7db23bR1-R8) [[3]](diffhunk://#diff-3a1f5a322e65200142bab1850f4de529911425b01a0fce6309d920364365aafaR1-R9) [[4]](diffhunk://#diff-fbc0f57b7d96ea89f7c59e51c6d44e3306add4d10b1e0968fe1c6e8880b504fbR1-R11)

### Model and Repository Layer Additions
* Added `Exam` and `Question` entities, including relationships with `Course` and each other. Exams are associated with courses, and questions are linked to exams. (`src/main/java/com/example/pal/model/Exam.java`, `src/main/java/com/example/pal/model/Question.java`) [[1]](diffhunk://#diff-3fcc316397808735f373e9da3c3f8957c7f75f4e834a9212443765607a476542R1-R53) [[2]](diffhunk://#diff-81dc2698f97c81b115c6753004eed204a1c61ff9d29b891afeb18cbb2e808b18R1-R32)
* Updated the `Course` model to include a one-to-many relationship with exams. (`src/main/java/com/example/pal/model/Course.java`)
* Created `ExamRepository` and `QuestionRepository` for database operations on exams and questions. (`src/main/java/com/example/pal/repository/ExamRepository.java`, `src/main/java/com/example/pal/repository/QuestionRepository.java`) [[1]](diffhunk://#diff-5e6f6935b8d4883c2256005bafe468532b51ef11df68e25eef258a24082ff2a2R1-R14) [[2]](diffhunk://#diff-014e3ca0ae664a2906aa290e53ae83c5717336445fb8fae6937cfd81d3d4de37R1-R12)

### Integration with Existing Features
* Updated the `CourseDTO` to include a set of associated exams, enabling the frontend to retrieve exam data alongside course details. (`src/main/java/com/example/pal/dto/CourseDTO.java`)…rvices